### PR TITLE
Fix insertion of armor items

### DIFF
--- a/utils/armor.lua
+++ b/utils/armor.lua
@@ -1,14 +1,8 @@
 Armor = {}
 
 local inventories = {
-    defines.inventory.player_main,
-    defines.inventory.player_vehicle,
-    defines.inventory.player_guns,
-    defines.inventory.player_ammo,
-    defines.inventory.player_armor,
-    defines.inventory.player_quickbar,
-    defines.inventory.player_tools,
-    defines.inventory.player_player_trash
+    defines.inventory.character_main,
+    defines.inventory.character_armor
 }
 
 function Armor.set_armor_items(player, armor_items_list)


### PR DESCRIPTION
Hi!
I checked out your mod but found the armor items in the medium and large kit to be not working.
I figured the main inventory and the armor inventory should be the only possible places for the power armor to be. As this is my first Factorio mod experience, you may want to double check what I did.

Thanks for creating this!